### PR TITLE
allow hidden columns

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -524,6 +524,13 @@ frappe.views.QueryReport = Class.extend({
 				col.field = df.fieldname || df.label;
 				df.label = __(df.label);
 				col.name = col.id = col.label = df.label;
+			
+				if(df.width < 0)
+				{
+					col = $.extend({}, col, {
+						hidden: true
+					});
+				}
 
 				return col
 			}));


### PR DESCRIPTION
this code allowes the script report to hide certain columns by simply placing their width to -1 or less

this can be praticularly useful in complex reports where we (for example) use dynamic links and we want to hide the field used to indicate the dynamic link